### PR TITLE
Specify table of contents in document

### DIFF
--- a/lib/caracal/core/fields.rb
+++ b/lib/caracal/core/fields.rb
@@ -1,0 +1,34 @@
+require 'caracal/core/models/field_model'
+require 'caracal/errors'
+
+
+module Caracal
+  module Core
+
+    # This module encapsulates all the functionality related to fields
+    #
+    module Fields
+      def self.included(base)
+        base.class_eval do
+
+          #-------------------------------------------------------------
+          # Public Methods
+          #-------------------------------------------------------------
+
+          def field(*args, &block)
+            options = Caracal::Utilities.extract_options!(args)
+            options.merge!({ type: args.first }) if args.first
+
+            model = Caracal::Core::Models::FieldModel.new(options, &block)
+            
+            if model.valid?
+              contents << model
+            end
+
+            model
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/caracal/core/models/field_model.rb
+++ b/lib/caracal/core/models/field_model.rb
@@ -15,7 +15,7 @@ module Caracal
         #--------------------------------------------------
 
         # constants
-        const_set(:TYPE_MAP, { page: 'PAGE', numpages: 'NUMPAGES' })
+        const_set(:TYPE_MAP, { page: 'PAGE', numpages: 'NUMPAGES', table_of_contents: 'TOC \o "1-1" \h \z \u \t "Heading 5,1"' })
 
         # accessors
         attr_reader :field_dirty
@@ -86,7 +86,7 @@ module Caracal
         end
 
         # strings
-        [:bgcolor, :color, :dirty, :font, :highlight_color, :style, :type,].each do |m|
+        [:bgcolor, :color, :dirty, :font, :highlight_color, :style, :type].each do |m|
           define_method "#{ m }" do |value|
             instance_variable_set("@field_#{ m }", value.to_s)
           end
@@ -115,19 +115,6 @@ module Caracal
 
         def option_keys
           [:type, :style, :font, :color, :size, :bold, :italic, :underline, :bgcolor, :highlight_color, :vertical_align]
-        end
-
-        def method_missing(method, *args, &block)
-          # TODO: Better field centric description
-
-          # I'm on the fence with respect to this implementation. We're ignoring
-          # :method_missing errors to allow syntax flexibility for paragraph-type
-          # models.  The issue is the syntax format of those models--the way we pass
-          # the content value as a special argument--coupled with the model's
-          # ability to accept nested instructions.
-          #
-          # By ignoring method missing errors here, we can pass the entire paragraph
-          # block in the initial, built-in call to :text.
         end
 
       end

--- a/lib/caracal/core/models/style_model.rb
+++ b/lib/caracal/core/models/style_model.rb
@@ -28,6 +28,7 @@ module Caracal
         const_set(:DEFAULT_STYLE_BOTTOM,     0)          # 0.0in  in twips
         const_set(:DEFAULT_STYLE_BASE,       'Normal')
         const_set(:DEFAULT_STYLE_NEXT,       'Normal')
+        const_set(:DEFAULT_STYLE_OUTLINE,    9)          # no level
 
         # accessors
         attr_reader :style_default
@@ -50,6 +51,7 @@ module Caracal
         attr_reader :style_indent_left
         attr_reader :style_indent_right
         attr_reader :style_indent_first
+        attr_reader :style_outline
 
         # initialization
         def initialize(options={}, &block)
@@ -72,6 +74,7 @@ module Caracal
             @style_top        ||= DEFAULT_STYLE_TOP
             @style_bottom     ||= DEFAULT_STYLE_BOTTOM
             @style_line       ||= DEFAULT_STYLE_LINE
+            @style_outline    ||= DEFAULT_STYLE_OUTLINE
           end
         end
 
@@ -97,7 +100,7 @@ module Caracal
         end
 
         # strings
-        [:id, :type, :name, :color, :font].each do |m|
+        [:id, :type, :name, :color, :font, :outline].each do |m|
           define_method "#{ m }" do |value|
             instance_variable_set("@style_#{ m }", value.to_s)
           end
@@ -155,7 +158,8 @@ module Caracal
             :align,
             :indent_left,
             :indent_right,
-            :indent_first ]
+            :indent_first,
+            :outline ]
         end
 
       end

--- a/lib/caracal/core/styles.rb
+++ b/lib/caracal/core/styles.rb
@@ -19,12 +19,12 @@ module Caracal
           def self.default_styles
             [
               { id: 'Normal',   name: 'normal',    font: 'Arial',    size: 20, line: 320, color: '333333' },
-              { id: 'Heading1', name: 'heading 1', font: 'Palatino', size: 36, bottom: 120 },
-              { id: 'Heading2', name: 'heading 2', font: 'Arial',    size: 26, top: 120, bottom: 160, bold: true },
-              { id: 'Heading3', name: 'heading 3', font: 'Arial',    size: 24, top: 120, bottom: 160, bold: true, italic: true, color: '666666' },
-              { id: 'Heading4', name: 'heading 4', font: 'Palatino', size: 24, top: 120, bottom: 120, bold: true },
-              { id: 'Heading5', name: 'heading 5', font: 'Arial',    size: 22, top: 120, bottom: 120, bold: true },
-              { id: 'Heading6', name: 'heading 6', font: 'Arial',    size: 22, top: 120, bottom: 120, underline: true, italic: true, color: '666666' },
+              { id: 'Heading1', name: 'heading 1', font: 'Palatino', size: 36, outline: 0, bottom: 120},
+              { id: 'Heading2', name: 'heading 2', font: 'Arial',    size: 26, outline: 1, top: 120, bottom: 160, bold: true },
+              { id: 'Heading3', name: 'heading 3', font: 'Arial',    size: 24, outline: 2, top: 120, bottom: 160, bold: true, italic: true, color: '666666' },
+              { id: 'Heading4', name: 'heading 4', font: 'Palatino', size: 24, outline: 3, top: 120, bottom: 120, bold: true },
+              { id: 'Heading5', name: 'heading 5', font: 'Arial',    size: 22, outline: 4, top: 120, bottom: 120, bold: true },
+              { id: 'Heading6', name: 'heading 6', font: 'Arial',    size: 22, outline: 5, top: 120, bottom: 120, underline: true, italic: true, color: '666666' },
               { id: 'Title',    name: 'title',     font: 'Palatino', size: 60 },
               { id: 'Subtitle', name: 'subtitle',  font: 'Arial',    size: 28, top: 60 }
             ]           

--- a/lib/caracal/document.rb
+++ b/lib/caracal/document.rb
@@ -3,6 +3,7 @@ require 'zip'
 
 require 'caracal/core/bookmarks'
 require 'caracal/core/custom_properties'
+require 'caracal/core/fields'
 require 'caracal/core/file_name'
 require 'caracal/core/fonts'
 require 'caracal/core/footer'
@@ -59,6 +60,7 @@ module Caracal
     include Caracal::Core::ListStyles
 
     include Caracal::Core::Bookmarks
+    include Caracal::Core::Fields
     include Caracal::Core::IFrames
     include Caracal::Core::Images
     include Caracal::Core::Lists

--- a/lib/caracal/renderers/settings_renderer.rb
+++ b/lib/caracal/renderers/settings_renderer.rb
@@ -22,6 +22,7 @@ module Caracal
             xml['w'].compat do
               xml['w'].compatSetting({ 'w:val' => '14', 'w:name' => 'compatibilityMode', 'w:uri' => 'http://schemas.microsoft.com/office/word' })
             end
+            xml['w'].updateFields({ 'w:val' => true })
           end
         end
         builder.to_xml(save_options)

--- a/lib/caracal/renderers/styles_renderer.rb
+++ b/lib/caracal/renderers/styles_renderer.rb
@@ -31,6 +31,7 @@ module Caracal
                   xml['w'].b({ 'w:val' => (s.style_bold ? '1' : '0') })
                   xml['w'].i({ 'w:val' => (s.style_italic ? '1' : '0') })
                   xml['w'].caps({ 'w:val' => (s.style_caps ? '1' : '0') })
+                  xml['w'].outlineLvl({ 'w:val' => s.style_outline })
                   xml['w'].smallCaps({ 'w:val' => '0' })
                   xml['w'].strike({ 'w:val' => '0' })
                   xml['w'].color({ 'w:val' => s.style_color })
@@ -75,6 +76,7 @@ module Caracal
                   xml['w'].widowControl({ 'w:val' => '1' })
                   xml['w'].spacing(spacing_options(s)) unless spacing_options(s).nil?
                   xml['w'].contextualSpacing({ 'w:val' => '1' })
+                  xml['w'].outlineLvl({ 'w:val' => s.style_outline }) unless s.style_outline.nil?
                   xml['w'].jc({ 'w:val' => s.style_align.to_s }) unless s.style_align.nil?
                   xml['w'].ind(indentation_options(s)) unless indentation_options(s).nil?
                 end

--- a/spec/lib/caracal/core/fields_spec.rb
+++ b/spec/lib/caracal/core/fields_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+describe Caracal::Core::Fields do
+  subject { Caracal::Document.new }
+  
+  
+  #-------------------------------------------------------------
+  # Public Methods
+  #-------------------------------------------------------------
+
+  describe 'public method tests' do
+    
+    # .table
+    describe '.field' do
+      let!(:size) { subject.contents.size }
+      
+      before { subject.field :table_of_contents }
+      
+      it { expect(subject.contents.size).to eq size + 1 }
+      it { expect(subject.contents.last).to be_a(Caracal::Core::Models::FieldModel) }
+    end
+    
+  end
+  
+end

--- a/spec/lib/caracal/core/models/style_model_spec.rb
+++ b/spec/lib/caracal/core/models/style_model_spec.rb
@@ -32,6 +32,7 @@ describe Caracal::Core::Models::StyleModel do
       it { expect(described_class::DEFAULT_STYLE_LINE).to eq 360 }
       it { expect(described_class::DEFAULT_STYLE_BASE).to eq 'Normal' }
       it { expect(described_class::DEFAULT_STYLE_NEXT).to eq 'Normal' }
+      it { expect(described_class::DEFAULT_STYLE_OUTLINE).to eq 9 }
     end
 
     # accessors
@@ -53,6 +54,7 @@ describe Caracal::Core::Models::StyleModel do
       it { expect(subject.style_line).to eq 360 }
       it { expect(subject.style_base).to eq 'Normal' }
       it { expect(subject.style_next).to eq 'Normal' }
+      it { expect(subject.style_outline).to eq 9 }
     end
 
   end
@@ -146,6 +148,11 @@ describe Caracal::Core::Models::StyleModel do
 
       it { expect(subject.style_font).to eq 'Helvetica' }
     end
+    describe '.outline' do
+      before { subject.outline(3) }
+
+      it { expect(subject.style_outline).to eq "3" }
+    end
 
     # symbols
     describe '.align' do
@@ -215,7 +222,7 @@ describe Caracal::Core::Models::StyleModel do
     # .option_keys
     describe '.option_keys' do
       let(:actual)   { subject.send(:option_keys).sort }
-      let(:expected) { [:type, :bold, :italic, :underline, :caps, :top, :bottom, :size, :line, :id, :name, :color, :font, :align, :indent_left, :indent_right, :indent_first].sort }
+      let(:expected) { [:type, :bold, :italic, :underline, :caps, :top, :bottom, :size, :line, :id, :name, :color, :font, :align, :indent_left, :indent_right, :indent_first, :outline].sort }
 
       it { expect(actual).to eq expected }
     end


### PR DESCRIPTION
## What is changing?

This PR facilitates creating a table of contents that auto-updates when the document loads.

## How has this been changed?

The `FieldModel` class has been expanded upon to accommodate (currently hard-coded) table-of-contents directives, while also introducing a `Fields` core entity that references this model. A new `:outline` property has also been added to the `Style` model, to capture the outline levels of headings by the styles renderer. An `updateFields` block has also been added to the document settings to prompt auto-updating the table-of-contents.

## How has this been tested?

A new test file covers the new `Fields` entity, while the test file for the `Styles` entity has been updated to handle the changes.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have created a [link to the Jira ticket](https://thecurveconsulting.atlassian.net/browse/PWM-263)
