### PR TITLE
PWM-263-V2: Specify table of contents in document

### DIFF
--- a/lib/caracal/core/models/field_model.rb
+++ b/lib/caracal/core/models/field_model.rb
@@ -15,7 +15,7 @@ module Caracal
         #--------------------------------------------------
 
         # constants
-        const_set(:TYPE_MAP, { page: 'PAGE', numpages: 'NUMPAGES', table_of_contents: 'TOC \o "1-1" \h \z \u \t "Heading 5,1"' })
+        const_set(:TYPE_MAP, { page: 'PAGE', numpages: 'NUMPAGES' })
 
         # accessors
         attr_reader :field_dirty

--- a/lib/caracal/core/models/table_of_contents_model.rb
+++ b/lib/caracal/core/models/table_of_contents_model.rb
@@ -1,0 +1,80 @@
+require 'caracal/core/models/base_model'
+
+
+module Caracal
+  module Core
+    module Models
+
+      # This class encapsulates the logic needed to store and manipulate
+      # text data.
+      #
+      class TableOfContentsModel < BaseModel
+
+        #--------------------------------------------------
+        # Configuration
+        #--------------------------------------------------
+
+        # constants
+        const_set(:DEFAULT_OPTS, 'TOC \o "1-1" \h \z \u \t "Heading 5,1"')
+        const_set(:DEFAULT_SIZE, 32)
+        const_set(:DEFAULT_TITLE, 'Table of Contents')
+
+        # accessors
+        attr_reader :toc_opts
+        attr_reader :toc_size
+        attr_reader :toc_title
+
+        #-------------------------------------------------------------
+        # Public Class Methods
+        #-------------------------------------------------------------
+        
+        # initialization
+        def initialize(options={}, &block)
+          @toc_opts  ||= DEFAULT_OPTS
+          @toc_size  ||= DEFAULT_SIZE
+          @toc_title ||= DEFAULT_TITLE
+          super options, &block
+        end
+
+        #-------------------------------------------------------------
+        # Public Instance Methods
+        #-------------------------------------------------------------
+
+        #=============== GETTERS ==============================
+
+        #========== GETTERS ===============================
+
+        #========== SETTERS ===============================
+
+        # integers
+        [:size].each do |m|
+          define_method "#{ m }" do |value|
+            instance_variable_set("@toc_#{ m }", value.to_i)
+          end
+        end
+
+        # strings
+        [:title, :opts].each do |m|
+          define_method "#{ m }" do |value|
+            instance_variable_set("@toc_#{ m }", value.to_s)
+          end
+        end
+
+        #========== VALIDATION ============================
+
+        def valid?
+          !!/^TOC/.match(toc_opts)
+        end
+
+        #--------------------------------------------------
+        # Private Methods
+        #--------------------------------------------------
+        private
+
+        def option_keys
+          [:opts, :size, :title]
+        end
+      end
+    end
+  end
+end

--- a/lib/caracal/core/models/table_of_contents_model.rb
+++ b/lib/caracal/core/models/table_of_contents_model.rb
@@ -63,7 +63,8 @@ module Caracal
         #========== VALIDATION ============================
 
         def valid?
-          !!/^TOC/.match(toc_opts)
+          a = [:opts, :size, :title]
+          a.map { |m| send("toc_#{ m }") }.compact.size == a.size
         end
 
         #--------------------------------------------------

--- a/lib/caracal/core/table_of_contents.rb
+++ b/lib/caracal/core/table_of_contents.rb
@@ -1,0 +1,34 @@
+require 'caracal/core/models/table_of_contents_model'
+require 'caracal/errors'
+
+
+module Caracal
+  module Core
+
+    # This module encapsulates all the functionality related to table of
+    # contents
+    #
+    module TableOfContents
+      def self.included(base)
+        base.class_eval do
+
+          #-------------------------------------------------------------
+          # Public Methods
+          #-------------------------------------------------------------
+
+          def table_of_contents(*args, &block)
+            options = Caracal::Utilities.extract_options!(args)
+
+            model = Caracal::Core::Models::TableOfContentsModel.new(options, &block)
+            
+            if model.valid?
+              contents << model
+            end
+
+            model
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/caracal/document.rb
+++ b/lib/caracal/document.rb
@@ -22,6 +22,7 @@ require 'caracal/core/relationships'
 require 'caracal/core/rules'
 require 'caracal/core/styles'
 require 'caracal/core/tables'
+require 'caracal/core/table_of_contents'
 require 'caracal/core/text'
 
 require 'caracal/renderers/app_renderer'
@@ -68,6 +69,7 @@ module Caracal
     include Caracal::Core::PageBreaks
     include Caracal::Core::Rules
     include Caracal::Core::Tables
+    include Caracal::Core::TableOfContents
     include Caracal::Core::Text
 
     include Caracal::Core::Footer

--- a/lib/caracal/renderers/document_renderer.rb
+++ b/lib/caracal/renderers/document_renderer.rb
@@ -220,6 +220,59 @@ module Caracal
         end
       end
 
+      def render_tableofcontents(xml, model)
+        xml['w'].sdt do
+          xml['w'].sdtPr do
+            xml['w'].docPartObj do
+              xml['w'].docPartGallery({ 'w:val' => model.toc_title })
+              xml['w'].docPartUnique({ 'w:val' => true })
+            end
+          end
+          xml['w'].sdtContent do
+            xml['w'].p do
+              xml['w'].pPr do
+                xml['w'].pStyle({ 'w:val' => 'ContentsHeading' })
+                xml['w'].rPr do
+                  xml['w'].b
+                  xml['w'].b
+                  xml['w'].bCs
+                  xml['w'].sz({ 'w:val' => model.toc_size })
+                  xml['w'].szCs({ 'w:val' => model.toc_size })
+                end
+              end
+              xml['w'].r do
+                  xml['w'].rPr do
+                  xml['w'].b
+                  xml['w'].bCs
+                  xml['w'].sz({ 'w:val' => model.toc_size })
+                  xml['w'].szCs({ 'w:val' => model.toc_size })
+                end
+                xml['w'].t model.toc_title
+              end
+            end
+            xml['w'].p do
+              xml['w'].r do
+                xml['w'].fldChar({ 'w:fldCharType' => 'begin' })
+              end
+              xml['w'].r do
+                xml['w'].rPr do
+                  render_run_attributes(xml, model, false)
+                end
+                xml['w'].instrText({ 'xml:space' => 'preserve' }) do
+                  xml.text " #{model.toc_opts} "
+                end
+              end
+              xml['w'].r do
+                xml['w'].fldChar({ 'w:fldCharType' => 'separate' })
+              end
+              xml['w'].r do
+                xml['w'].fldChar({ 'w:fldCharType' => 'end' })
+              end
+            end
+          end
+        end
+      end
+
       def render_field(xml, model)
         xml['w'].r do
           xml['w'].fldChar({ 'w:fldCharType' => 'begin' })

--- a/lib/caracal/version.rb
+++ b/lib/caracal/version.rb
@@ -1,3 +1,3 @@
 module Caracal
-  VERSION = '1.4.2'
+  VERSION = '1.4.3'
 end

--- a/spec/lib/caracal/core/models/table_of_contents_model_spec.rb
+++ b/spec/lib/caracal/core/models/table_of_contents_model_spec.rb
@@ -1,0 +1,91 @@
+require 'spec_helper'
+
+describe Caracal::Core::Models::TableOfContentsModel do
+  subject do
+    described_class.new
+  end
+
+
+  #-------------------------------------------------------------
+  # Configuration
+  #-------------------------------------------------------------
+
+  describe 'configuration tests' do
+
+    # accessors
+    describe 'accessors' do
+      it { expect(subject.toc_opts).to eq 'TOC \o "1-1" \h \z \u \t "Heading 5,1"' }
+      it { expect(subject.toc_size).to eq 32 }
+      it { expect(subject.toc_title).to eq 'Table of Contents' }
+    end
+  end
+
+
+  #-------------------------------------------------------------
+  # Public Methods
+  #-------------------------------------------------------------
+
+  describe 'public method tests' do
+    #=============== GETTERS ==========================
+
+
+    #=============== SETTERS ==========================
+
+    # integers
+    describe '.size' do
+      before { subject.size(24) }
+
+      it { expect(subject.toc_size).to eq 24 }
+    end
+
+    # strings
+    describe '.opts' do
+      before { subject.opts('TOC \o "1-1"') }
+
+      it { expect(subject.toc_opts).to eq 'TOC \o "1-1"' }
+    end
+    describe '.title' do
+      before { subject.title('Hello World') }
+
+      it { expect(subject.toc_title).to eq 'Hello World' }
+    end
+
+    #=============== VALIDATION ===========================
+
+    describe '.valid?' do
+      describe 'when the opts exist' do
+        before do
+          allow(subject).to receive(:opts).and_return('TOC \o "1-1"')
+        end
+
+        it { expect(subject.valid?).to eq true }
+      end
+      describe 'when no runs exist' do
+        before do
+          allow(subject).to receive(:opts).and_return(nil)
+        end
+
+        it { expect(subject.valid?).to eq false }
+      end
+    end
+
+  end
+
+
+  #-------------------------------------------------------------
+  # Private Methods
+  #-------------------------------------------------------------
+
+  describe 'private method tests' do
+
+    # .option_keys
+    describe '.option_keys' do
+      let(:actual)   { subject.send(:option_keys).sort }
+      let(:expected) { [:opts, :size, :title].sort }
+
+      it { expect(actual).to eq expected }
+    end
+
+  end
+
+end

--- a/spec/lib/caracal/core/models/table_of_contents_model_spec.rb
+++ b/spec/lib/caracal/core/models/table_of_contents_model_spec.rb
@@ -53,19 +53,17 @@ describe Caracal::Core::Models::TableOfContentsModel do
     #=============== VALIDATION ===========================
 
     describe '.valid?' do
-      describe 'when the opts exist' do
-        before do
-          allow(subject).to receive(:opts).and_return('TOC \o "1-1"')
-        end
-
+      describe 'when name provided' do
         it { expect(subject.valid?).to eq true }
       end
-      describe 'when no runs exist' do
-        before do
-          allow(subject).to receive(:opts).and_return(nil)
+      [:opts, :size, :title].each do |prop|
+        describe "when #{ prop } nil" do
+          before do
+            allow(subject).to receive("font_#{ prop }").and_return(nil)
+          end
+        
+          it { expect(subject.valid?).to eq true }
         end
-
-        it { expect(subject.valid?).to eq false }
       end
     end
 


### PR DESCRIPTION
This PR reworks the table of contents into a separate entity, and introduces the necessary details to make the table of contents appear anywhere within the document.