### PR TITLE
PWM-262-V2: Specify portrait and landscape page orientations in the same document

### DIFF
--- a/lib/caracal/renderers/document_renderer.rb
+++ b/lib/caracal/renderers/document_renderer.rb
@@ -331,6 +331,12 @@ module Caracal
         xml['w'].p paragraph_options do
           xml['w'].pPr do
             xml['w'].sectPr do
+              if rel = document.find_relationship('footer1.xml')
+                xml['w'].footerReference({ 'r:id' => rel.formatted_id, 'w:type' => 'default' })
+              end
+              if rel = document.find_relationship('header1.xml')
+                xml['w'].headerReference({ 'r:id' => rel.formatted_id, 'w:type' => 'default' })
+              end
               xml['w'].pgSz({
                 'w:w' => document.page_width,
                 'w:h' => document.page_height
@@ -345,6 +351,12 @@ module Caracal
         xml['w'].p paragraph_options do
           xml['w'].pPr do
             xml['w'].sectPr do
+              if rel = document.find_relationship('footer1.xml')
+                xml['w'].footerReference({ 'r:id' => rel.formatted_id, 'w:type' => 'default' })
+              end
+              if rel = document.find_relationship('header1.xml')
+                xml['w'].headerReference({ 'r:id' => rel.formatted_id, 'w:type' => 'default' })
+              end
               xml['w'].pgSz({
                 'w:w' => document.page_height,
                 'w:h' => document.page_width

--- a/lib/caracal/version.rb
+++ b/lib/caracal/version.rb
@@ -1,3 +1,3 @@
 module Caracal
-  VERSION = '1.4.3'
+  VERSION = '1.4.4'
 end


### PR DESCRIPTION
This PR fixes a regression where headers and footers were only visible on the last section of a document.