### PR TITLE
PWM-262: Specify portrait and landscape page orientations in the same document

### DIFF
--- a/lib/caracal/core/models/page_flip_model.rb
+++ b/lib/caracal/core/models/page_flip_model.rb
@@ -13,6 +13,11 @@ module Caracal
         # Configuration
         #-------------------------------------------------------------
 
+        # accessors
+        attr_reader :page_width
+        attr_reader :page_margin_left
+        attr_reader :page_margin_right
+
         # initialization
         def initialize(options={}, &block)
           super options, &block
@@ -21,6 +26,15 @@ module Caracal
         #-------------------------------------------------------------
         # Public Methods
         #-------------------------------------------------------------
+        
+        #========== SETTERS ===============================
+
+        # integers
+        [:width, :margin_left, :margin_right].each do |m|
+          define_method "#{ m }" do |value|
+            instance_variable_set("@page_#{ m }", value.to_i)
+          end
+        end
 
         #=============== DATA ACCESSORS =======================
 
@@ -34,6 +48,15 @@ module Caracal
         # .valid?
         def valid?
           contents.size > 0
+        end
+
+        #--------------------------------------------------
+        # Private Instance Methods
+        #--------------------------------------------------
+        private
+
+        def option_keys
+          [:width, :margin_left, :margin_right]
         end
       end
     end

--- a/lib/caracal/core/page_flips.rb
+++ b/lib/caracal/core/page_flips.rb
@@ -19,6 +19,15 @@ module Caracal
           def page_flip(*args, &block)
             options = Caracal::Utilities.extract_options!(args)
 
+            # Pass through the page dimensions from the parent document,
+            # using the page height as the page width, due to it using
+            # the inverse dimensions.
+            options.merge!({
+              width: page_height,
+              margin_left: page_margin_left,
+              margin_right: page_margin_right
+            })
+
             model = Caracal::Core::Models::PageFlipModel.new(options, &block)
             
             if model.valid?

--- a/lib/caracal/version.rb
+++ b/lib/caracal/version.rb
@@ -1,3 +1,3 @@
 module Caracal
-  VERSION = '1.4.4'
+  VERSION = '1.4.5'
 end

--- a/spec/lib/caracal/core/tables_spec.rb
+++ b/spec/lib/caracal/core/tables_spec.rb
@@ -18,8 +18,21 @@ describe Caracal::Core::Tables do
       
       it { expect(subject.contents.size).to eq size + 1 }
       it { expect(subject.contents.last).to be_a(Caracal::Core::Models::TableModel) }
+      it { expect(subject.contents.last.table_width).to be(9360) }
     end
-    
+
+    describe '.table within a page-flip' do
+      let!(:size) { subject.contents.size }
+      
+      before do
+        subject.page_flip do |x|
+          x.table [['Sample Text']]
+        end
+      end
+      
+      it { expect(subject.contents.size).to eq size + 1 }
+      it { expect(subject.contents.last.contents.first).to be_a(Caracal::Core::Models::TableModel) }
+      it { expect(subject.contents.last.contents.first.table_width).to be(12960) }
+    end
   end
-  
 end


### PR DESCRIPTION
This PR fixes issues in Microsoft Word specifically where the table dimensions are not set correctly when rendered inside a `PageFlip` component.

This is due to the `Table` component expecting the `page_width`, `page_margin_left` and `page_margin_right` attributes to exist on the parent component, which usually is the `Document` itself. By passing these properties through to the `PageFlip` component, the tables now render correctly.