### PR TITLE
PWM-269: Do not create a new paragraph on page break

### DIFF
--- a/lib/caracal/renderers/document_renderer.rb
+++ b/lib/caracal/renderers/document_renderer.rb
@@ -367,17 +367,7 @@ module Caracal
       end
 
       def render_pagebreak(xml, model)
-        if model.page_break_wrap
-          xml['w'].p paragraph_options do
-            xml['w'].r run_options do
-              xml['w'].br({ 'w:type' => 'page' })
-            end
-          end
-        else
-          xml['w'].r run_options do
-            xml['w'].br({ 'w:type' => 'page' })
-          end
-        end
+        @pagebreak_on_next_paragraph = true
       end
 
       def render_paragraph(xml, model)
@@ -389,6 +379,10 @@ module Caracal
             xml['w'].contextualSpacing({ 'w:val' => '0' })
             xml['w'].jc({ 'w:val' => model.paragraph_align })  unless model.paragraph_align.nil?
             render_run_attributes(xml, model, true)
+            if @pagebreak_on_next_paragraph
+              xml['w'].pageBreakBefore
+              @pagebreak_on_next_paragraph = false
+            end
           end
           model.runs.each do |run|
             method = render_method_for_model(run)

--- a/lib/caracal/version.rb
+++ b/lib/caracal/version.rb
@@ -1,3 +1,3 @@
 module Caracal
-  VERSION = '1.4.5'
+  VERSION = '1.4.6'
 end


### PR DESCRIPTION
A page break has to happen from within a paragraph tag.
Previously, this was occurring in a separate paragraph, which lead to an empty paragraph, and then a page break.
This commit will ensure that these empty paragraphs are not generated.