### PR TITLE
Fix can't insert image in x64-mingw-ucrt

### DIFF
--- a/lib/caracal/document.rb
+++ b/lib/caracal/document.rb
@@ -224,8 +224,11 @@ module Caracal
       images.each do |rel|
         if rel.relationship_data.to_s.size > 0
           content = rel.relationship_data
+        elsif rel.relationship_target[/^https?/]
+          # path is url
+          content = URI.open(rel.relationship_target).read
         else
-          content = open(rel.relationship_target).read
+          content = open(rel.relationship_target,'rb').read
         end
 
         zip.put_next_entry("word/#{ rel.formatted_target }")


### PR DESCRIPTION
The original author seems to have given up.
Ruby version : ruby 3.2.5 (2024-07-26 revision 31d0f1a2e7) [x64-mingw-ucrt]
**Test Code**
```ruby
require 'uri'
require 'open-uri'


begin
content = URI.open('https://www.tgkw.com/images/banner/banner_001.png').read
puts "It's ok. content size :#{content.bytesize}"
rescue => e
  puts "It's error. #{e.message}"
end

begin
  content = open('https://www.tgkw.com/images/banner/banner_001.png').read
  puts "It's ok. content size :#{content.bytesize}"
rescue => e
  puts "It's error. #{e.message}"
end

begin
  content = open('H:/desktop/QQ20241226-165608.png').read
  puts "It's ok. content size :#{content.bytesize}"
rescue => e
  puts "It's error. #{e.message}"
end

begin
  content = open('H:/desktop/QQ20241226-165608.png','rb').read
  puts "It's ok. content size :#{content.bytesize}"
rescue => e
  puts "It's error. #{e.message}"
end
```
**Output**
```text
It's ok. content size :715201
It's error. Invalid argument @ rb_sysopen - https://www.tgkw.com/images/banner/banner_001.png
It's ok. content size :5
It's ok. content size :204185
```