### PR TITLE
Update URI opening to work with Ruby 3+

### DIFF
--- a/lib/caracal/document.rb
+++ b/lib/caracal/document.rb
@@ -251,7 +251,7 @@ module Caracal
         if rel.relationship_data.to_s.size > 0
           content = rel.relationship_data
         else
-          content = open(rel.relationship_target).read
+          content = URI.open(rel.relationship_target).read
         end
 
         zip.put_next_entry("word/#{ rel.formatted_target }")

--- a/lib/caracal/version.rb
+++ b/lib/caracal/version.rb
@@ -1,3 +1,3 @@
 module Caracal
-  VERSION = '1.4.6'
+  VERSION = '1.4.7'
 end


### PR DESCRIPTION
This PR replaces `open(...)` with `URI.open(...)` as per Ruby 3 standards, to fix the following error:
```
No such file or directory @ rb_sysopen
```