### PR TITLE
SIFE-22: Table of contents does not respect page breaks

### DIFF
--- a/lib/caracal/renderers/document_renderer.rb
+++ b/lib/caracal/renderers/document_renderer.rb
@@ -247,6 +247,10 @@ module Caracal
                   xml['w'].sz({ 'w:val' => model.toc_size })
                   xml['w'].szCs({ 'w:val' => model.toc_size })
                 end
+                if @pagebreak_on_next_paragraph
+                  xml['w'].br({ 'w:type' => 'page' })
+                  @pagebreak_on_next_paragraph = false
+                end
                 xml['w'].t model.toc_title
               end
             end

--- a/lib/caracal/version.rb
+++ b/lib/caracal/version.rb
@@ -1,3 +1,3 @@
 module Caracal
-  VERSION = '1.4.7'
+  VERSION = '1.4.8'
 end


### PR DESCRIPTION
This PR introduces an optional page break to the table-of-contents component.